### PR TITLE
Fix examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
     <script>
          window.onload = function() {
           const ui = SwaggerUIBundle({
-            url: "https://raw.githubusercontent.com/autifyhq/autify-api/master/swagger.yml",
+            url: "swagger.yml",
             dom_id: '#swagger-ui',
             deepLinking: true,
             presets: [

--- a/swagger.yml
+++ b/swagger.yml
@@ -38,7 +38,7 @@ paths:
           required: true
           description: |
             For example, the `{id}` for the following URL is **3**.
-            `https://app.autify.com/projects/1/test_plans/3`
+            `https://app.autify.com/schedules/3`
           schema:
             type: integer
       responses:
@@ -97,7 +97,7 @@ paths:
           required: true
           description: |
             For example, the `{project_id}` for the following URL is **1**.<br/>
-            `https://app.autify.com/projects/1/scenarios`
+            `https://app.autify.com/projects/1/scenarios/2`
           schema:
             type: integer
         - name: id
@@ -130,7 +130,7 @@ paths:
           required: true
           description: |
             For example, the `{project_id}` for the following URL is **1**.<br/>
-            `https://app.autify.com/projects/1/scenarios`
+            `https://app.autify.com/projects/1/results`
           schema:
             type: integer
         - name: page
@@ -173,7 +173,7 @@ paths:
           required: true
           description: |
             For example, the `{project_id}` for the following URL is **1**.<br/>
-            `https://app.autify.com/projects/1/scenarios`
+            `https://app.autify.com/projects/1/results/4`
           schema:
             type: integer
         - name: id


### PR DESCRIPTION
I fixed some descriptions.
And also I changed the way to specify YAML.

Because the `index.html` and `swagger.yml` are placed in the same directory, we can use relative form.
It's easy to run and confirm locally.

https://autifyhq.github.io/autify-api/index.html
https://autifyhq.github.io/autify-api/swagger.yml